### PR TITLE
fix: 🐛 more accepting rules

### DIFF
--- a/app/schemas/answer_schema.py
+++ b/app/schemas/answer_schema.py
@@ -7,4 +7,4 @@ class FieldSchema(Schema):
 
 class AnswerSchema(Schema):
     field = fields.Nested(FieldSchema(), required=True)
-    value = fields.Integer(required=True)
+    value = fields.Raw(required=True)


### PR DESCRIPTION
field tag value can be int or date string