### PR TITLE
fix(format-answers): added statement to check if passed tag is valid

### DIFF
--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -227,8 +227,12 @@ class VivaApplication(Viva):
             element_type_tag = self._find_tag_by_element_type(
                 tag_list=tag_list)
 
+            if element_type_tag is None:
+                continue
+
             # lon:0, get lon
             item_type = element_type_tag.split(':')[0]
+            
 
             item = element_item_dict.get(element_type_tag, {
                 'TYPE': item_type,
@@ -360,3 +364,5 @@ class VivaApplication(Viva):
                 return self._helpers.serialize_object(completion_response)
         except Exception as error:
             raise error
+
+class Answers(object):

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -364,5 +364,3 @@ class VivaApplication(Viva):
                 return self._helpers.serialize_object(completion_response)
         except Exception as error:
             raise error
-
-class Answers(object):


### PR DESCRIPTION
## Explain the changes you’ve made
Added check to se if a passed tag is valid or not.

## How to test the changes?

1. Checkout this branch
2. Setup the python environment
3. Start the application with flask run 
4. Send a POST request to the /applications endpoint with a none valid tag init.

Result nothing should break in the adapter and an 200 response should be returned.

**OBS**: If you want to test this all the way to VIVA you need to setup an ssh tunnel to the correct internal network.

Example POST body:
```JSON
{
  "applicationType": "recurrent",
  "hashid": "a_user_hash_id",
  "workflowId": "",
  "answers": [
   {
      "field": {
        "id": "lon-date",
        "tags": [
          "incomes",
          "lon:0",
          "date"
        ]
      },
      "value": 1611270000000
   },
  {
      "field": {
        "id": "lon-amount",
        "tags": [
          "incomes",
          "lon:0", 
          "amount"
        ]
      },
      "value": 4250
    },
   {
      "field": {
        "id": "bredband-amount",
        "tags": [
          "incomes",
          "bredband",
          "date"
        ]
      },
      "value": 1611270000000
   },
     {
      "field": {
        "id": "bredband-date",
        "tags": [
          "incomes",
          "bredband",
          "date"
        ]
      },
      "value": 256
   },
    {
      "field": {
        "id": "none-valid-tag-1",
        "tags": [
          "incomes",
          "fel", //none valid tag
          "date"
        ]
      },
      "value": 1611270000000
   },
 {
      "field": {
        "id": "none-valid-tag-2",
        "tags": [
          "incomes",
          "fel:0", // none valid tag
          "date"
        ]
      },
      "value": 1611270000000
   }
  ] 
 }
```

## Was this feature tested in the following environments?
- [X] Locally
