### PR TITLE
Fix/application status response time

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,7 +37,7 @@ def create_app():
         )
 
         api.add_resource(
-            routes.ApplicationsStatus,
+            routes.ApplicationStatus,
             '/applications/<string:hash_id>/status',
         )
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,6 +34,10 @@ def create_app():
         api.add_resource(
             routes.Applications,
             '/applications',
+        )
+
+        api.add_resource(
+            routes.ApplicationsStatus,
             '/applications/<string:hash_id>/status',
         )
 

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -1,4 +1,10 @@
-from .classes import Session, DataClassApplication, Viva, VivaMyPages, VivaApplication, VivaAttachments
+from .classes import Session
+from .classes import DataClassApplication
+from .classes import Viva
+from .classes import VivaMyPages
+from .classes import VivaApplication
+from .classes import VivaApplicationStatus
+from .classes import VivaAttachments
 
 from .personal_number_helper import hashids_instace, hash_to_personal_number
 from .datetime_helper import milliseconds_to_date_string

--- a/app/libs/classes/__init__.py
+++ b/app/libs/classes/__init__.py
@@ -4,3 +4,4 @@ from .viva import Viva
 from .viva_my_pages import VivaMyPages
 from .viva_attachments import VivaAttachments
 from .viva_application import VivaApplication
+from .viva_application_status import VivaApplicationStatus

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -18,16 +18,16 @@ class VivaApplication(Viva):
         super(VivaApplication, self).__init__()
 
         if not isinstance(application, DataClassApplication):
-            raise Fault(
-                message='application should be an instance of DataClassApplication', code=500)
+            raise TypeError(
+                f'{application} is not an instance of class DataClassApplication')
 
         if my_pages and not isinstance(my_pages, VivaMyPages):
-            raise Fault(
-                message='my_pages should be an instance of VivaMyPages', code=500)
+            raise TypeError(
+                f'{my_pages} is not an instance of class VivaMyPages')
 
         if viva_attachments and not isinstance(viva_attachments, VivaAttachments):
-            raise Fault(
-                message='viva_attachments should be an instance of VivaAttachments', code=500)
+            raise TypeError(
+                f'{viva_attachments} is not an instance of class VivaAttachments')
 
         self._my_pages = my_pages
         self._viva_attachments = viva_attachments

--- a/app/libs/classes/viva_application_status.py
+++ b/app/libs/classes/viva_application_status.py
@@ -7,12 +7,11 @@ class VivaApplicationStatus(Viva):
     def __init__(self, wsdl='VivaApplication', personal_number=None):
         super(VivaApplicationStatus, self).__init__()
 
-        self._service = self._get_service(wsdl)
-
-        if not isinstance(personal_number, str) or len(personal_number) < 11:
-            raise Fault(message='Incorrect personal number', code=400)
+        if not isinstance(personal_number, str):
+            raise TypeError('personal_number should be type string')
 
         self._personal_number = personal_number
+        self._service = self._get_service(wsdl)
 
     def get(self):
         """

--- a/app/libs/classes/viva_application_status.py
+++ b/app/libs/classes/viva_application_status.py
@@ -10,7 +10,7 @@ class VivaApplicationStatus(Viva):
         self._service = self._get_service(wsdl)
 
         if not isinstance(personal_number, str) or len(personal_number) < 11:
-            raise Fault(message='User missing', code=400)
+            raise Fault(message='Incorrect personal number', code=400)
 
         self._personal_number = personal_number
 
@@ -61,11 +61,11 @@ class VivaApplicationStatus(Viva):
             512: 'Ärendet tillåter e-ansökan',
         }
 
-        statuses = list()
+        status_list = list()
 
         if status_number > 128:
             key = 128
-            statuses.append({
+            status_list.append({
                 'code': key,
                 'description': status_description[key]
             })
@@ -73,7 +73,7 @@ class VivaApplicationStatus(Viva):
 
         if status_number > 256:
             key = 256
-            statuses.append({
+            status_list.append({
                 'code': key,
                 'description': status_description[key]
             })
@@ -81,21 +81,21 @@ class VivaApplicationStatus(Viva):
 
         if status_number > 512:
             key = 512
-            statuses.append({
+            status_list.append({
                 'code': key,
                 'description': status_description[key]
             })
             status_number -= key
 
         if status_number in status_description:
-            statuses.append({
+            status_list.append({
                 'code': status_number,
                 'description': status_description[status_number]
             })
         else:
-            statuses.append({
+            status_list.append({
                 'code': status_number,
                 'description': 'N/A'
             })
 
-        return self._helpers.serialize_object(statuses)
+        return self._helpers.serialize_object(status_list)

--- a/app/libs/classes/viva_application_status.py
+++ b/app/libs/classes/viva_application_status.py
@@ -1,0 +1,101 @@
+from zeep.exceptions import Fault
+
+from . import Viva
+
+
+class VivaApplicationStatus(Viva):
+    def __init__(self, wsdl='VivaApplication', personal_number=None):
+        super(VivaApplicationStatus, self).__init__()
+
+        self._service = self._get_service(wsdl)
+
+        if not isinstance(personal_number, str) or len(personal_number) < 11:
+            raise Fault(message='User missing', code=400)
+
+        self._personal_number = personal_number
+
+    def get(self):
+        """
+        ApplicationStatus förklaring:
+
+        -1 - fel (t.ex. person finns inte i personregistret)
+
+        eller summan av:
+        1 - ansökan tillåten
+        2 - autosave finns (man har påbörjat en ansökan)
+        4 - väntar signering (avser medsökande: sökande har signerat en ansökan som inkluderar medsökande)
+        8 - väntar att medsökande ska signera (avser sökande medan hen väntar på att medsökande ska signera)
+        16 - ansökan inskickad
+        32 - ansökan mottagen(/registrerad i Viva)
+        64 - komplettering begärd
+        128 - ärende finns (försörjningsstödsärende)
+        256 - ett ärende är aktiverat på web (egenskap på ärendet som gör att det visas på Mina sidor)
+        512 - ärendet tillåter e-ansökan  (egenskap på ärendet som gör att det går att skapa fortsatt ansökan)
+
+        2, 4 och 8 blir bara aktuella när man parkerar eller autosparar ansökan i Viva.
+
+        Det är bara när ApplicationStatus innehåller 1 (summan är udda) som ansökan kan lämnas in.
+
+        128 + 256 + 512 kommer i princip alltid att vara med eftersom ett ärende som tillåter e-ansökan är en förutsättning för fortsatt ansökan.
+
+        När ApplicationStatus bara är 1 finns inget ärende och man kan lämna in en grundansökan.
+        """
+
+        status_number = self._service.APPLICATIONSTATUS(
+            SUSER=self._personal_number,
+            SPNR=self._personal_number,
+            SCASETYPE='01',  # 01 = EKB
+            SSYSTEM=1
+        )
+
+        status_description = {
+            1: 'Ansökan tillåten',
+            2: 'Autosave',
+            4: 'Väntar signering',
+            8: 'Väntar att medsökande ska signera',
+            16: 'Ansökan inskickad',
+            32: 'Ansökan mottagen/registrerad',
+            64: 'Komplettering begärd',
+            128: 'Arende finns (försörjningsstödsärende)',
+            256: 'Ett ärende är aktiverat på webben',
+            512: 'Ärendet tillåter e-ansökan',
+        }
+
+        statuses = list()
+
+        if status_number > 128:
+            key = 128
+            statuses.append({
+                'code': key,
+                'description': status_description[key]
+            })
+            status_number -= key
+
+        if status_number > 256:
+            key = 256
+            statuses.append({
+                'code': key,
+                'description': status_description[key]
+            })
+            status_number -= key
+
+        if status_number > 512:
+            key = 512
+            statuses.append({
+                'code': key,
+                'description': status_description[key]
+            })
+            status_number -= key
+
+        if status_number in status_description:
+            statuses.append({
+                'code': status_number,
+                'description': status_description[status_number]
+            })
+        else:
+            statuses.append({
+                'code': status_number,
+                'description': 'N/A'
+            })
+
+        return self._helpers.serialize_object(statuses)

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -8,18 +8,18 @@ from flask import current_app
 hashids_instace = Hashids(salt=current_app.config['SALT'], min_length=32)
 
 
-def hash_to_personal_number(hash_id=str):
+def hash_to_personal_number(hash_id=None):
     if not hash_id:
-        raise Fault(message='invalide hash_id', code=400)
+        raise TypeError('hash_id should be type string')
 
-    try:
-        personal_number = str(hashids_instace.decode(hash_id)[0])
-        if current_app.config['ENV'] in ['development', 'test']:
-            personal_number = to_test_personal_number(personal_number)
+    if not len(hash_id) == 32:
+        raise Fault(message='Invalid hash_id', code=400)
 
-        return personal_number
-    except Exception as e:
-        raise Fault(e.args, code=500)
+    personal_number = str(hashids_instace.decode(hash_id)[0])
+    if current_app.config['ENV'] in ['development', 'test']:
+        personal_number = to_test_personal_number(personal_number)
+
+    return personal_number
 
 
 def to_test_personal_number(personal_number=str):

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,6 +1,7 @@
 from .my_pages import MyPages
 from .my_pages_workflows import MyPagesWorkflows
 from .applications import Applications
+from .application_status import ApplicationStatus
 from .attachments import Attachments
 from .attachment import Attachment
 from .completions import Completions

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -7,8 +7,11 @@ from ..libs import hash_to_personal_number
 
 class ApplicationStatus(Resource):
 
-    def get(self, hash_id=None):
+    def get(self, hash_id):
         try:
+            if not hash_id:
+                raise TypeError('hash_id should be type string')
+
             personal_number = hash_to_personal_number(hash_id=hash_id)
 
             viva_application_status = VivaApplicationStatus(
@@ -19,15 +22,13 @@ class ApplicationStatus(Resource):
             return response, 200
 
         except Fault as fault:
-            error = dict({
+            return {
+                'message': fault.message,
+                'code': fault.code,
+            }, fault.code
+
+        except Exception as error:
+            return {
+                'message': f'{error}',
                 'code': 500,
-                'message': 'Internal Server Error',
-            })
-
-            if fault.code:
-                error['code'] = fault.code
-
-            if fault.message:
-                error['message'] = fault.message
-
-            return error, error.get('code')
+            }, 500

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -1,0 +1,33 @@
+from flask_restful import Resource
+from zeep.exceptions import Fault
+
+from ..libs import VivaApplicationStatus
+from ..libs import hash_to_personal_number
+
+
+class ApplicationStatus(Resource):
+
+    def get(self, hash_id=None):
+        try:
+            personal_number = hash_to_personal_number(hash_id=hash_id)
+
+            viva_application_status = VivaApplicationStatus(
+                personal_number=personal_number)
+
+            response = viva_application_status.get()
+
+            return response, 200
+
+        except Fault as fault:
+            error = dict({
+                'code': 500,
+                'message': 'Internal Server Error',
+            })
+
+            if fault.code:
+                error['code'] = fault.code
+
+            if fault.message:
+                error['message'] = fault.message
+
+            return error, error.get('code')

--- a/app/routes/applications.py
+++ b/app/routes/applications.py
@@ -17,24 +17,6 @@ from ..schemas import ResponseSchema
 class Applications(Resource):
     method_decorators = [authenticate]
 
-    def get(self, hash_id=None):
-        try:
-            personal_number = hash_to_personal_number(hash_id=hash_id)
-
-            viva_application = VivaApplication(
-                my_pages=VivaMyPages(user=personal_number),
-                application=DataClassApplication(operation_type='status'))
-
-            response = viva_application.submit()
-
-            return response, 200
-
-        except Fault as fault:
-            return {
-                'message': fault.message,
-                'code': fault.code
-            }, fault.code
-
     def post(self):
         try:
             json_payload = request.json

--- a/app/routes/applications.py
+++ b/app/routes/applications.py
@@ -40,10 +40,22 @@ class Applications(Resource):
             response_schema = ResponseSchema()
             validated_response = response_schema.load(response)
 
+            if validated_response['status'] == 'Error':
+                raise Fault(
+                    message='Something went wrong when submitting the application to Viva', code=500,
+                    subcodes=[validated_response])
+
             return validated_response
+
+        except Fault as fault:
+            return {
+                'message': fault.message,
+                'code': fault.code,
+                'subCodes': fault.subcodes,
+            }, fault.code
 
         except Exception as error:
             return {
                 'message': f'{error}',
-                'code': 400
-            }, 400
+                'code': 500
+            }, 500


### PR DESCRIPTION
Vad?
Utbrytning av viva operation APPLICATIONSTATUS till separat klass som slipper beroendet av MyPages-klassen

Varför?
MyPages-klassens konstruktor utför förfrågningar mot viva som ApplicationStatus inte behöver.

Test?
Kör uppslag mot /applications/...hashid.../status
Svarstiden väntas blir kortare mot tidigare

