### PR TITLE
feat(answer-tags): support for parsing a group tag in answer tags

### DIFF
--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -234,7 +234,7 @@ class VivaApplication(Viva):
 
             group_tag = self._find_group_tag(tag_list)
             if group_tag:
-                dict_item_key = group_tag
+                dict_item_key = '{}#{}'.format(dict_item_key, group_tag)
             
 
             item = element_item_dict.get(dict_item_key, {

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -230,11 +230,14 @@ class VivaApplication(Viva):
             if element_type_tag is None:
                 continue
 
-            # lon:0, get lon
-            item_type = element_type_tag.split(':')[0]
+            dict_item_key = element_type_tag
+
+            group_tag = self._find_group_tag(tag_list)
+            if group_tag:
+                dict_item_key = group_tag
             
 
-            item = element_item_dict.get(element_type_tag, {
+            item = element_item_dict.get(dict_item_key, {
                 'TYPE': item_type,
                 'FREQUENCY': 12,
                 'DATE': '',
@@ -252,7 +255,7 @@ class VivaApplication(Viva):
             if 'amount' in tag_list:
                 item['AMOUNT'] = str(answer['value'])
 
-            element_item_dict[element_type_tag] = item
+            element_item_dict[dict_item_key] = item
 
         element_item_list = self._convert_dict_to_list(dict=element_item_dict)
         return element_item_list
@@ -261,6 +264,10 @@ class VivaApplication(Viva):
         filtered_answer_list = list(
             filter(lambda answer: tag_name in answer['field']['tags'], self._answers))
         return filtered_answer_list
+
+    def _find_group_tag(self, tag_list):
+        group_tag = next((tag for tag in tag_list if tag.startswith('group')), None)
+        return group_tag
 
     def _find_tag_by_element_type(self, tag_list):
         element_type_list = {

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -234,7 +234,7 @@ class VivaApplication(Viva):
 
             group_tag = self._find_group_tag(tag_list)
             if group_tag:
-                dict_item_key = '{}#{}'.format(dict_item_key, group_tag)
+                dict_item_key = f'{dict_item_key}#{group_tag}'
             
 
             item = element_item_dict.get(dict_item_key, {

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -235,10 +235,9 @@ class VivaApplication(Viva):
             group_tag = self._find_group_tag(tag_list)
             if group_tag:
                 dict_item_key = f'{dict_item_key}#{group_tag}'
-            
 
             item = element_item_dict.get(dict_item_key, {
-                'TYPE': item_type,
+                'TYPE': element_type_tag,
                 'FREQUENCY': 12,
                 'DATE': '',
                 'PERIOD': '',

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -289,7 +289,8 @@ class VivaApplication(Viva):
             'swish': 'Swish',
             'bil': 'Bil',
             'mobile': 'Mobiltelefon',
-            'annat': 'Övrigt',
+            'annat': 'Övrig utgift',
+            'annan': 'Övrig inkomst',
             'other_attachments': 'Övriga underlag',
         }
 

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -266,7 +266,7 @@ class VivaApplication(Viva):
         return filtered_answer_list
 
     def _find_group_tag(self, tag_list):
-        group_tag = next((tag for tag in tag_list if tag.startswith('group')), None)
+        group_tag = next((tag for tag in tag_list if tag.startswith('group:')), None)
         return group_tag
 
     def _find_tag_by_element_type(self, tag_list):

--- a/app/libs/classes/viva_application.py
+++ b/app/libs/classes/viva_application.py
@@ -265,7 +265,8 @@ class VivaApplication(Viva):
         return filtered_answer_list
 
     def _find_group_tag(self, tag_list):
-        group_tag = next((tag for tag in tag_list if tag.startswith('group:')), None)
+        group_tag = next(
+            (tag for tag in tag_list if tag.startswith('group:')), None)
         return group_tag
 
     def _find_tag_by_element_type(self, tag_list):
@@ -293,7 +294,7 @@ class VivaApplication(Viva):
         }
 
         tag = next(
-            (tag for tag in tag_list if tag.split(':')[0] in element_type_list.keys()), None)
+            (tag for tag in tag_list if tag in element_type_list.keys()), None)
 
         return tag
 

--- a/tmp/new_re_appli_post.json
+++ b/tmp/new_re_appli_post.json
@@ -1,90 +1,57 @@
 {
-  "application_type": "renew",
-  "user_hash": "INSERT_HASHED_PERSON_NUMBER_HERE ie: <197105016161>",
-  "data": {
-    "REAPPLICATION": {
-      "RAWDATA": "TESTING CREATE RE-APPLICATION USING VADA API ADAPTER",
-      "RAWDATATYPE": "PDF",
-      "HOUSEHOLDINFO": "STUFF",
-      "EXPENSES": [
-        {
-          "EXPENSE": {
-            "TYPE": "Mobiltelefon",
-            "DESCRIPTION": "avtal",
-            "APPLIESTO": "coapplicant",
-            "FREQUENCY": 12,
-            "PERIOD": "2020-05-01 - 2020-05-31",
-            "AMOUNT": 199,
-            "DATE": "2020-05-08"
-          }
-        },
-        {
-          "EXPENSE": {
-            "TYPE": "Mobiltelefon",
-            "DESCRIPTION": "avtal",
-            "APPLIESTO": "applicant",
-            "FREQUENCY": 12,
-            "PERIOD": "2020-05-01 - 2020-05-31",
-            "AMOUNT": 169,
-            "DATE": "2020-05-08"
-          }
-        }
-      ],
-      "INCOMES": [
-        {
-          "INCOME": {
-            "TYPE": "Hyra",
-            "DESCRIPTION": "Uthyrning av garage",
-            "APPLIESTO": "applicant",
-            "FREQUENCY": 12,
-            "PERIOD": "2020-05-01 - 2020-05-31",
-            "AMOUNT": 250,
-            "DATE": "2020-05-08"
-          }
-        }
-      ],
-      "ASSETS": [
-        {
-          "ASSET": {
-            "TYPE": "MC",
-            "DESCRIPTION": "Motocross",
-            "APPLIESTO": "applicant",
-            "AMOUNT": 16000
-          }
-        },
-        {
-          "ASSET": {
-            "TYPE": "Bil",
-            "DESCRIPTION": "Opel Ascona med körförbud",
-            "APPLIESTO": "applicant",
-            "AMOUNT": 4000
-          }
-        }
-      ],
-      "OTHER": "Lite text från Övriga upplysningar. Till exempel om du sökt utbildning eller planering med Arbetsförmedlingen.",
-      "SIGNATURES": [
-        {
-          "SIGNATURE": {
-            "ID": "19710501T6161",
-            "VISIBLEDATA": "Härmed intygar jag att...",
-            "NONVISIBLEDATA": "data",
-            "SIGNATUREDATA": "data",
-            "OCSPRESPONSE": "data",
-            "TRANSACTIONID": 1232,
-            "IP": "127.0.0.1",
-            "TIMESTAMP": "2020-05-08T23:46:00+01:00"
-          }
-        }
-      ]
+  "applicationType": "recurrent",
+  "hashid": "yPVvdwDqmoN9JEd1op7401EGWQ8xjRL5",
+  "workflowId": "",
+  "answers": [
+    {
+      "field": {
+        "id": "id1",
+        "tags": [
+          "incomes",
+          "lon",
+          "amount",
+          "group:0"
+        ]
+      },
+      "value": 7000
     },
-    "NOTIFYINFOS": [
-      {
-        "NOTIFYINFO": {
-          "ID": "19710501T6161",
-          "ADDRESS": "070555555",
-          "ADDRESSTYPE": "sms"
-        }
-      }
-    ]
-  }
+    {
+      "field": {
+        "id": "id2",
+        "tags": [
+          "incomes",
+          "lon",
+          "date",
+          "group:0"
+        ]
+      },
+      "value": 1611270000000
+    },
+    {
+      "field": {
+        "id": "id3",
+        "tags": [
+          "incomes",
+          "lon",
+          "amount",
+          "group:1"
+        ]
+      },
+      "value": 2321
+    },
+    {
+      "field": {
+        "id": "id4",
+        "tags": [
+          "incomes",
+          "lon",
+          "date",
+          "group:1"
+        ]
+      },
+      "value": 1611280000000
+    }
+  ],
+  "rawDataType": "pdf",
+  "rawData": ""
 }

--- a/tmp/new_re_appli_post.json
+++ b/tmp/new_re_appli_post.json
@@ -50,6 +50,42 @@
         ]
       },
       "value": 1611280000000
+    },
+    {
+      "field": {
+        "id": "id5",
+        "tags": [
+          "incomes",
+          "annan",
+          "amount",
+          "group:0"
+        ]
+      },
+      "value": 6781
+    },
+    {
+      "field": {
+        "id": "id5",
+        "tags": [
+          "incomes",
+          "annan",
+          "amount",
+          "group:1"
+        ]
+      },
+      "value": 561
+    },
+    {
+      "field": {
+        "id": "id5",
+        "tags": [
+          "incomes",
+          "annan",
+          "amount",
+          "group:1"
+        ]
+      },
+      "value": 345
     }
   ],
   "rawDataType": "pdf",


### PR DESCRIPTION
The parsing of case answers now supports passing a group tag in answer tags. This allows for
grouping several answer values into the same zeep xml object.

## Explain the changes you’ve made
Added support for parsing a group tag from answer tags. This allows for grouping values in different answers on the same object. One answer might be the date for a salary and another answer defines the date. By adding a group tag these answers can now reference to the same salary.

## Explain your solution
When parsing incoming answers from an application post request to a zeep xml dict, we now look in the tag list for each answer to see if there is a group tag. If there is a group tag in the list we look if there is a post assigned to this group already and assign the value to based on other tag definitions. if the group tag does not exist we add it so that other answers with the same tag can add values on the same post.

The group tag syntax is the following: group:x (where x indicates an identifier for a group).

Example Answers object with group tags
```JSON
[{
    "field": {
        "id": "lon0",
        "tags": ["incomes", "lon", "amount", "group:0"]
    },
    "value": 1000
}, {
    "field": {
        "id": "lon0",
        "tags": ["incomes", "lon", "date", "group:0"]
    },
    "value": 1611270000000
}, {
    "field": {
        "id": "lon1",
        "tags": ["incomes", "lon", "amount", "group:1"]
    },
    "value": 2000
}, {
    "field": {
        "id": "lon1",
        "tags": ["incomes", "lon", "date", "group:1"]
    },
    "value": 1611270000000
}, {
    "field": {
        "id": "internet",
        "tags": ["expenses", "bredband", "amount"]
    },
    "value": 200
}, {
    "field": {
        "id": "internet",
        "tags": ["expenses", "bredband", "date"]
    },
    "value": 1611270000000
}]
```

## How to test the changes?

1. Checkout this branch
2. Start the Adapter server (flask run)
3. Make a POST request towards /applications

Request body to use:
```JSON
{
  "applicationType": "recurrent",
  "hashid": "INSERT_USER_HASH_ID",
  "workflowId": "",
  "answers":[{
    "field": {
        "id": "lon0",
        "tags": ["incomes", "lon", "amount", "group:0"]
    },
    "value": 1000
}, {
    "field": {
        "id": "lon0",
        "tags": ["incomes", "lon", "date", "group:0"]
    },
    "value": 1611270000000
}, {
    "field": {
        "id": "lon1",
        "tags": ["incomes", "lon", "amount", "group:1"]
    },
    "value": 2000
}, {
    "field": {
        "id": "lon1",
        "tags": ["incomes", "lon", "date", "group:1"]
    },
    "value": 1611270000000
}, {
    "field": {
        "id": "internet",
        "tags": ["expenses", "bredband", "amount"]
    },
    "value": 200
}, {
    "field": {
        "id": "internet",
        "tags": ["expenses", "bredband", "date"]
    },
    "value": 1611270000000
}],
  "rawDataType": "pdf",
  "rawData": {
    "type": "Buffer",
    "data": []
  }
}
```

