### PR TITLE
Feat/flask restful error handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,52 +1,5 @@
 from flask import Flask, jsonify
-from flask_restful import Api
-from werkzeug.http import HTTP_STATUS_CODES
-from werkzeug.exceptions import HTTPException
-from requests.exceptions import ConnectionError
-from marshmallow.exceptions import ValidationError as MarshmallowValidationError
-
-
-class ExtendedFlaskRestfulApi(Api):
-
-    def handle_error(self, error):
-        print('Error: ', error)
-
-        if isinstance(error, HTTPException):
-            details = error.message
-            return self._error_response(error=error, status_code=error.code, details=details)
-
-        if isinstance(error, ConnectionError):
-            details = error.message
-            status_code = 502
-            return self._error_response(error=error, status_code=status_code, details=details)
-
-        if isinstance(error, MarshmallowValidationError):
-            details = error.messages
-            status_code = 400
-            return self._error_response(error=error, status_code=status_code, details=details)
-
-        if not getattr(error, 'message', None):
-            details = 'Server has encountered an unexpected error'
-            status_code = 500
-            return self._error_response(error=error, status_code=status_code, details=details)
-
-        # Handle application specific custom exceptions
-        return jsonify(**error.kwargs), error.http_status_code
-
-    def _error_response(self, error, status_code, details):
-        description = getattr(
-            error, 'description', HTTP_STATUS_CODES.get(status_code, '')
-        )
-
-        _dict = {
-            'error': {
-                'code': status_code,
-                'description': description,
-                'details': details,
-            }
-        }
-
-        return _dict, status_code
+from .api import ExtendedFlaskRestfulApi
 
 
 def create_app():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from flask_restful import Api
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug.exceptions import HTTPException
 from requests.exceptions import ConnectionError
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 
 
 class ExtendedFlaskRestfulApi(Api):
@@ -11,26 +12,41 @@ class ExtendedFlaskRestfulApi(Api):
         print('Error: ', error)
 
         if isinstance(error, HTTPException):
-            return {
-                'message': getattr(
-                    error, 'description', HTTP_STATUS_CODES.get(error.code, '')
-                )
-            }, error.code
+            details = error.message
+            return self._error_response(error=error, status_code=error.code, details=details)
 
         if isinstance(error, ConnectionError):
-            return {
-                'message': getattr(
-                    error, 'description', HTTP_STATUS_CODES.get(502, '')
-                )
-            }, 502
+            details = error.message
+            status_code = 502
+            return self._error_response(error=error, status_code=status_code, details=details)
+
+        if isinstance(error, MarshmallowValidationError):
+            details = error.messages
+            status_code = 400
+            return self._error_response(error=error, status_code=status_code, details=details)
 
         if not getattr(error, 'message', None):
-            return {
-                'message': 'Server has encountered some error'
-            }, 500
+            details = 'Server has encountered an unexpected error'
+            status_code = 500
+            return self._error_response(error=error, status_code=status_code, details=details)
 
         # Handle application specific custom exceptions
         return jsonify(**error.kwargs), error.http_status_code
+
+    def _error_response(self, error, status_code, details):
+        description = getattr(
+            error, 'description', HTTP_STATUS_CODES.get(status_code, '')
+        )
+
+        _dict = {
+            'error': {
+                'code': status_code,
+                'description': description,
+                'details': details,
+            }
+        }
+
+        return _dict, status_code
 
 
 def create_app():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask, jsonify
-from .api import ExtendedFlaskRestfulApi
+from .api import CustomFlaskRestfulApi
 
 
 def create_app():
@@ -16,7 +16,7 @@ def create_app():
 
         from . import routes
 
-        api = ExtendedFlaskRestfulApi(app)
+        api = CustomFlaskRestfulApi(app)
 
         # Viva adapter api endpoints
         api.add_resource(

--- a/app/api.py
+++ b/app/api.py
@@ -30,14 +30,12 @@ class ExtendedFlaskRestfulApi(Api):
             return self._error_response(error=error, status_code=status_code, details=details)
 
         # Handle application specific custom exceptions
-        return jsonify(**error.kwargs), error.http_status_code
+        return **error.kwargs, error.http_status_code
 
     def _error_response(self, error, status_code, details):
-        description = getattr(
-            error, 'description', HTTP_STATUS_CODES.get(status_code, '')
-        )
+        description = HTTP_STATUS_CODES.get(status_code, '')
 
-        _dict = {
+        response = {
             'error': {
                 'code': status_code,
                 'description': description,
@@ -45,4 +43,4 @@ class ExtendedFlaskRestfulApi(Api):
             }
         }
 
-        return _dict, status_code
+        return response, status_code

--- a/app/api.py
+++ b/app/api.py
@@ -5,7 +5,7 @@ from requests.exceptions import ConnectionError
 from marshmallow.exceptions import ValidationError as MarshmallowValidationError
 
 
-class ExtendedFlaskRestfulApi(Api):
+class CustomFlaskRestfulApi(Api):
 
     def handle_error(self, error):
         print('Error: ', error)

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,48 @@
+from flask_restful import Api
+from werkzeug.http import HTTP_STATUS_CODES
+from werkzeug.exceptions import HTTPException
+from requests.exceptions import ConnectionError
+from marshmallow.exceptions import ValidationError as MarshmallowValidationError
+
+
+class ExtendedFlaskRestfulApi(Api):
+
+    def handle_error(self, error):
+        print('Error: ', error)
+
+        if isinstance(error, HTTPException):
+            details = error.message
+            return self._error_response(error=error, status_code=error.code, details=details)
+
+        if isinstance(error, ConnectionError):
+            details = error.message
+            status_code = 502
+            return self._error_response(error=error, status_code=status_code, details=details)
+
+        if isinstance(error, MarshmallowValidationError):
+            details = error.messages
+            status_code = 400
+            return self._error_response(error=error, status_code=status_code, details=details)
+
+        if not getattr(error, 'message', None):
+            details = 'Server has encountered an unexpected error'
+            status_code = 500
+            return self._error_response(error=error, status_code=status_code, details=details)
+
+        # Handle application specific custom exceptions
+        return jsonify(**error.kwargs), error.http_status_code
+
+    def _error_response(self, error, status_code, details):
+        description = getattr(
+            error, 'description', HTTP_STATUS_CODES.get(status_code, '')
+        )
+
+        _dict = {
+            'error': {
+                'code': status_code,
+                'description': description,
+                'details': details,
+            }
+        }
+
+        return _dict, status_code

--- a/app/api.py
+++ b/app/api.py
@@ -32,7 +32,7 @@ class ExtendedFlaskRestfulApi(Api):
         # Handle application specific custom exceptions
         return **error.kwargs, error.http_status_code
 
-    def _error_response(self, error, status_code, details):
+    def _error_response(self, status_code, details):
         description = HTTP_STATUS_CODES.get(status_code, '')
 
         response = {

--- a/app/data/users.py
+++ b/app/data/users.py
@@ -1,13 +1,13 @@
 from flask import current_app
-from ..libs import hashids_instace
+from ..libs import hashids_instance
 
 
 def insert_pnr_and_endpoints(personal_number):
     return {
         'pnr': personal_number,
-        'mypages_url': '/mypages/' + hashids_instace.encode(personal_number),
-        'mypages_workflows_url': '/mypages/' + hashids_instace.encode(personal_number) + '/workflows',
-        'applications_status_url': '/applications/' + hashids_instace.encode(personal_number) + '/status',
+        'mypages_url': '/mypages/' + hashids_instance.encode(personal_number),
+        'mypages_workflows_url': '/mypages/' + hashids_instance.encode(personal_number) + '/workflows',
+        'applications_status_url': '/applications/' + hashids_instance.encode(personal_number) + '/status',
     }
 
 

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,0 +1,2 @@
+from .base_error import BaseError
+from .validation_error import ValidationError

--- a/app/errors/base_error.py
+++ b/app/errors/base_error.py
@@ -5,10 +5,9 @@ class BaseError(Exception):
         # the msg while raising the exception
         self.http_status_code = http_status_code
         self.kwargs = kwargs
-        msg = kwargs.get('msg', kwargs.get('message'))
-        if msg:
-            args = (msg,)
-            super().__init__(args)
+        message = kwargs.get('message')
+        if message:
+            super().__init__(message)
         self.args = list(args)
         for key in kwargs.keys():
             setattr(self, key, kwargs[key])

--- a/app/errors/base_error.py
+++ b/app/errors/base_error.py
@@ -1,0 +1,14 @@
+class BaseError(Exception):
+    def __init__(self, http_status_code: int, *args, **kwargs):
+        # If the key `msg` is provided, provide the msg string
+        # to Exception class in order to display
+        # the msg while raising the exception
+        self.http_status_code = http_status_code
+        self.kwargs = kwargs
+        msg = kwargs.get('msg', kwargs.get('message'))
+        if msg:
+            args = (msg,)
+            super().__init__(args)
+        self.args = list(args)
+        for key in kwargs.keys():
+            setattr(self, key, kwargs[key])

--- a/app/errors/base_error.py
+++ b/app/errors/base_error.py
@@ -1,8 +1,5 @@
 class BaseError(Exception):
     def __init__(self, http_status_code: int, *args, **kwargs):
-        # If the key `msg` is provided, provide the msg string
-        # to Exception class in order to display
-        # the msg while raising the exception
         self.http_status_code = http_status_code
         self.kwargs = kwargs
         message = kwargs.get('message')

--- a/app/errors/validation_error.py
+++ b/app/errors/validation_error.py
@@ -2,7 +2,6 @@ from . import BaseError
 
 
 class CustomValidationError(BaseError):
-    """ Should be raised in case of custom validation """
 
     def __init__(self, message):
         super().__init__(http_status_code=400, message=message)

--- a/app/errors/validation_error.py
+++ b/app/errors/validation_error.py
@@ -1,7 +1,7 @@
 from . import BaseError
 
 
-class ValidationError(BaseError):
+class CustomValidationError(BaseError):
     """ Should be raised in case of custom validation """
 
     def __init__(self, message):

--- a/app/errors/validation_error.py
+++ b/app/errors/validation_error.py
@@ -1,4 +1,4 @@
-from .base_error import BaseError
+from . import BaseError
 
 
 class ValidationError(BaseError):

--- a/app/errors/validation_error.py
+++ b/app/errors/validation_error.py
@@ -1,0 +1,8 @@
+from .base_error import BaseError
+
+
+class ValidationError(BaseError):
+    """ Should be raised in case of custom validation """
+
+    def __init__(self, message):
+        super().__init__(http_status_code=400, message=message)

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -6,6 +6,6 @@ from .classes import VivaApplication
 from .classes import VivaApplicationStatus
 from .classes import VivaAttachments
 
-from .personal_number_helper import hashids_instace, hash_to_personal_number
+from .personal_number_helper import hashids_instace, hash_to_personal_number, decode_hash_id
 from .datetime_helper import milliseconds_to_date_string
 from .authenticate_helper import authenticate

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -6,6 +6,9 @@ from .classes import VivaApplication
 from .classes import VivaApplicationStatus
 from .classes import VivaAttachments
 
-from .personal_number_helper import hashids_instance, hash_to_personal_number, decode_hash_id
+from .personal_number_helper import hashids_instance,
+from .personal_number_helper import hash_to_personal_number
+from .personal_number_helper import decode_hash_id
+
 from .datetime_helper import milliseconds_to_date_string
 from .authenticate_helper import authenticate

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -6,6 +6,6 @@ from .classes import VivaApplication
 from .classes import VivaApplicationStatus
 from .classes import VivaAttachments
 
-from .personal_number_helper import hashids_instace, hash_to_personal_number, decode_hash_id
+from .personal_number_helper import hashids_instance, hash_to_personal_number, decode_hash_id
 from .datetime_helper import milliseconds_to_date_string
 from .authenticate_helper import authenticate

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -6,7 +6,7 @@ from .classes import VivaApplication
 from .classes import VivaApplicationStatus
 from .classes import VivaAttachments
 
-from .personal_number_helper import hashids_instance,
+from .personal_number_helper import hashids_instance
 from .personal_number_helper import hash_to_personal_number
 from .personal_number_helper import decode_hash_id
 

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -1,18 +1,32 @@
 import re
 from flask import jsonify
 from hashids import Hashids
+from ..errors import HashIdError
 
 from flask import current_app
 
-hashids_instace = Hashids(salt=current_app.config['SALT'], min_length=32)
+hashids_instance = Hashids(salt=current_app.config['SALT'], min_length=32)
+
+
+def decode_hash_id(hash_id: str = None):
+   try
+       if not isinstance(hash_id, str):
+            raise TypeError(
+                f'expected hash_id to be of type string got {hash_id} instead')
+
+        return hashids_instance.decode(hash_id)
+    except:
+        return ()
 
 
 def hash_to_personal_number(hash_id=None):
-    if not isinstance(hash_id, str):
-        raise TypeError(
-            f'expected hash_id to be of type string got {hash_id} instead')
 
-    personal_number = str(hashids_instace.decode(hash_id)[0])
+    decoded_hash_id_tuple = decode_hash_id(hash_id)
+
+    if len(decoded_hash_id_tuple) == 0:
+        return None
+
+    personal_number = str(int_tuple[0])
 
     if current_app.config['ENV'] in ['development', 'test']:
         personal_number = to_test_personal_number(personal_number)

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -1,7 +1,6 @@
 import re
 from flask import jsonify
 from hashids import Hashids
-from zeep.exceptions import Fault
 
 from flask import current_app
 
@@ -9,13 +8,12 @@ hashids_instace = Hashids(salt=current_app.config['SALT'], min_length=32)
 
 
 def hash_to_personal_number(hash_id=None):
-    if not hash_id:
-        raise TypeError('hash_id should be type string')
-
-    if not len(hash_id) == 32:
-        raise Fault(message='Invalid hash_id', code=400)
+    if not isinstance(hash_id, str):
+        raise TypeError(
+            f'expected hash_id to be of type string got {hash_id} instead')
 
     personal_number = str(hashids_instace.decode(hash_id)[0])
+
     if current_app.config['ENV'] in ['development', 'test']:
         personal_number = to_test_personal_number(personal_number)
 

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -8,14 +8,11 @@ hashids_instance = Hashids(salt=current_app.config['SALT'], min_length=32)
 
 
 def decode_hash_id(hash_id: str = None):
-    try:
-        if not isinstance(hash_id, str):
-            raise TypeError(
-                f'expected hash_id to be of type string got {hash_id} instead')
+    if not isinstance(hash_id, str):
+        raise TypeError(
+            f'expected hash_id to be of type string got {hash_id} instead')
 
-        return hashids_instance.decode(hash_id)
-    except:
-        return ()
+    return hashids_instance.decode(hash_id)
 
 
 def hash_to_personal_number(hash_id=None):
@@ -23,7 +20,8 @@ def hash_to_personal_number(hash_id=None):
     decoded_hash_id_tuple = decode_hash_id(hash_id)
 
     if len(decoded_hash_id_tuple) == 0:
-        return None
+        raise ValueError(
+            f'Expected decoded_hash_id_tuple to have atleast one value (a,) got {decoded_hash_id_tuple} instead')
 
     personal_number = str(int_tuple[0])
 

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -9,7 +9,7 @@ hashids_instance = Hashids(salt=current_app.config['SALT'], min_length=32)
 
 
 def decode_hash_id(hash_id: str = None):
-   try
+   try:
        if not isinstance(hash_id, str):
             raise TypeError(
                 f'expected hash_id to be of type string got {hash_id} instead')

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -1,7 +1,6 @@
 import re
 from flask import jsonify
 from hashids import Hashids
-from ..errors import HashIdError
 
 from flask import current_app
 
@@ -9,8 +8,8 @@ hashids_instance = Hashids(salt=current_app.config['SALT'], min_length=32)
 
 
 def decode_hash_id(hash_id: str = None):
-   try:
-       if not isinstance(hash_id, str):
+    try:
+        if not isinstance(hash_id, str):
             raise TypeError(
                 f'expected hash_id to be of type string got {hash_id} instead')
 

--- a/app/libs/personal_number_helper.py
+++ b/app/libs/personal_number_helper.py
@@ -17,13 +17,13 @@ def decode_hash_id(hash_id: str = None):
 
 def hash_to_personal_number(hash_id=None):
 
-    decoded_hash_id_tuple = decode_hash_id(hash_id)
+    decoded_hash_id = decode_hash_id(hash_id)
 
-    if len(decoded_hash_id_tuple) == 0:
+    if len(decoded_hash_id) == 0:
         raise ValueError(
             f'Expected decoded_hash_id_tuple to have atleast one value (a,) got {decoded_hash_id_tuple} instead')
 
-    personal_number = str(int_tuple[0])
+    personal_number = str(decoded_hash_id[0])
 
     if current_app.config['ENV'] in ['development', 'test']:
         personal_number = to_test_personal_number(personal_number)

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -3,32 +3,23 @@ from zeep.exceptions import Fault
 
 from ..libs import VivaApplicationStatus
 from ..libs import hash_to_personal_number
+from ..errors import ValidationError
 
 
 class ApplicationStatus(Resource):
 
     def get(self, hash_id):
-        try:
-            if not hash_id:
-                raise TypeError('hash_id should be type string')
+        if not len(hash_id) == 32:
+            raise ValidationError(
+                message=f'The hashid {hash_id} in the url is not a valid hashid')
 
-            personal_number = hash_to_personal_number(hash_id=hash_id)
+        personal_number = hash_to_personal_number(hash_id=hash_id)
+        print(personal_number)
 
-            viva_application_status = VivaApplicationStatus(
-                personal_number=personal_number)
+        viva_application_status = VivaApplicationStatus(
+            personal_number=personal_number)
+        print(viva_application_status)
 
-            response = viva_application_status.get()
+        response = viva_application_status.get()
 
-            return response, 200
-
-        except Fault as fault:
-            return {
-                'message': fault.message,
-                'code': fault.code,
-            }, fault.code
-
-        except Exception as error:
-            return {
-                'message': f'{error}',
-                'code': 500,
-            }, 500
+        return response, 200

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -4,7 +4,7 @@ from zeep.exceptions import Fault
 
 from ..libs import VivaApplicationStatus
 from ..libs import decode_hash_id
-from ..errors import ValidationError
+from ..errors import CustomValidationError
 
 
 class ApplicationStatus(Resource):
@@ -13,7 +13,7 @@ class ApplicationStatus(Resource):
         decoded_hash_id = decode_hash_id(hash_id=hash_id)
 
         if len(decoded_hash_id) == 0:
-            raise ValidationError(
+            raise CustomValidationError(
                 message=f'The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).')
 
         personal_number = decoded_hash_id[0]

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -14,7 +14,7 @@ class ApplicationStatus(Resource):
 
         if len(hash_id_tuple) == 0:
             raise ValidationError(
-                message=f'The hashid {hash_id} in the url is not a valid hashid')
+                message=f'The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).')
 
         personal_number = hash_id_tuple[0]
 

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -10,13 +10,13 @@ from ..errors import ValidationError
 class ApplicationStatus(Resource):
 
     def get(self, hash_id):
-        hash_id_tuple = decode_hash_id(hash_id=hash_id)
+        decoded_hash_id = decode_hash_id(hash_id=hash_id)
 
-        if len(hash_id_tuple) == 0:
+        if len(decoded_hash_id) == 0:
             raise ValidationError(
                 message=f'The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).')
 
-        personal_number = hash_id_tuple[0]
+        personal_number = decoded_hash_id[0]
 
         if current_app.config['ENV'] in ['development', 'test']:
             personal_number = to_test_personal_number(personal_number)

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -1,4 +1,5 @@
 from flask_restful import Resource
+from flask import current_app
 from zeep.exceptions import Fault
 
 from ..libs import VivaApplicationStatus

--- a/app/routes/application_status.py
+++ b/app/routes/application_status.py
@@ -2,23 +2,26 @@ from flask_restful import Resource
 from zeep.exceptions import Fault
 
 from ..libs import VivaApplicationStatus
-from ..libs import hash_to_personal_number
+from ..libs import decode_hash_id
 from ..errors import ValidationError
 
 
 class ApplicationStatus(Resource):
 
     def get(self, hash_id):
-        if not len(hash_id) == 32:
+        hash_id_tuple = decode_hash_id(hash_id=hash_id)
+
+        if len(hash_id_tuple) == 0:
             raise ValidationError(
                 message=f'The hashid {hash_id} in the url is not a valid hashid')
 
-        personal_number = hash_to_personal_number(hash_id=hash_id)
-        print(personal_number)
+        personal_number = hash_id_tuple[0]
+
+        if current_app.config['ENV'] in ['development', 'test']:
+            personal_number = to_test_personal_number(personal_number)
 
         viva_application_status = VivaApplicationStatus(
             personal_number=personal_number)
-        print(viva_application_status)
 
         response = viva_application_status.get()
 


### PR DESCRIPTION
## Feature description
This feature adds the functionlity to catch all errors raised in the code base and format them to http error responses with the correct status code.

## Solution description
The flask_restful Api class have a function built in to catch all errors that is raised within the application. This function (handle_errors) can also be overwritten to handle raised errors in the way we want to. So the solution was to simply extend the flas_restful Api class and override the handle_errors function. 

## What areas is affected by these changes?.
These changes currently only effect the application_status resource since that's the only resource that take advantage of this new funtionality. All endpoints however do have support for this behavior, but since we handle the errors in eact endpoints by try except blocks the error_handler never triggers.

## Testing the changes?
To test these changes you need to do the following:

1. Make sure your environment is setup according to the readme file
2. Checkout this branch
3. run commands: $ pipenv shell-> $ pipenv install -> $ flask run
4. Make requests to the route application/{hash_id}/status, with invalid hash_ids of any kind
5. This should result in a 400 Bad Request Error response.

Further more if you break the code in some way the error handler will catch this and return a 500 Internal server error.

## Was this feature tested in the following environments?
- [x] Your personal VADA environment.