### PR TITLE
fix: use float for amount

### DIFF
--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -115,7 +115,7 @@ class ZeepApplication(dict):
                     milliseconds=value)
 
             elif attribute == 'AMOUNT':
-                post[attribute] = int(value)
+                post[attribute] = float(value)
 
             elif attribute == 'COAPPLICANT':
                 post['APPLIESTO'] = name


### PR DESCRIPTION
# What has changed

Change AMOUNT fields to convert to `float` instead of `int`, to support decimal amounts (ören).

Note: VIVA accepts double-precision, meaning values can be very precise (e.g. `123.456789`) and will be automatically rounded by VIVA (e.g. to `123.46`).

# How to test

1) Checkout this branch and setup adapter
2) Send a request as usual but specify some amounts in decimals (e.g. `1000.00`, `123.4567` etc.)
3) Verify nothing crashes and the amounts are correctly submitted to VIVA