### PR TITLE
fix: check for coapplicant value in appliesto attribute

### DIFF
--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -121,7 +121,7 @@ class ZeepApplication(dict):
             elif attribute == 'AMOUNT':
                 post[attribute] = float(value)
 
-            elif attribute == 'APPLIESTO':
+            elif attribute == 'APPLIESTO' and value == 'COAPPLICANT':
                 post[attribute] = 'coapplicant'
 
         return post


### PR DESCRIPTION
In the form answers the `APPLIESTO` field is now used by the PDF generation to group fields by applicant/coapplicant/children.

This adapter fix correctly handles these changes and only sets the outgoing (to VIVA) `APPLIESTO` to `coapplicant` if the incoming value is `COAPPLICANT` (also note the difference in caps), and defaulting to `'APPLIESTO': 'applicant'` for all other cases (like children).