### PR TITLE
Feat/get workflow completions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,6 +37,11 @@ def create_app():
         )
 
         api.add_resource(
+            routes.MyPagesWorkflowCompletions,
+            '/mypages/<string:hash_id>/workflows/<string:workflow_id>/completions',
+        )
+
+        api.add_resource(
             routes.Applications,
             '/applications',
         )

--- a/app/libs/__init__.py
+++ b/app/libs/__init__.py
@@ -5,6 +5,7 @@ from .classes import VivaMyPages
 from .classes import VivaApplication
 from .classes import VivaApplicationStatus
 from .classes import VivaAttachments
+from .classes import VivaWorkflowCompletionsMapper
 
 from .personal_number_helper import get_hash_ids
 from .personal_number_helper import hash_to_personal_number

--- a/app/libs/classes/__init__.py
+++ b/app/libs/classes/__init__.py
@@ -5,3 +5,4 @@ from .viva_my_pages import VivaMyPages
 from .viva_attachments import VivaAttachments
 from .viva_application import VivaApplication
 from .viva_application_status import VivaApplicationStatus
+from .mappers.viva_workflow_completions_mapper import VivaWorkflowCompletionsMapper

--- a/app/libs/classes/mappers/tests/test_viva_persons_to_applicants_mapper.py
+++ b/app/libs/classes/mappers/tests/test_viva_persons_to_applicants_mapper.py
@@ -1,5 +1,5 @@
 import pytest
-from .viva_persons_to_applicants_mapper import VivaPersonsToApplicantsMapper
+from ..viva_persons_to_applicants_mapper import VivaPersonsToApplicantsMapper
 
 
 def test_happy_path():

--- a/app/libs/classes/mappers/tests/test_viva_workflow_completions_mapper.py
+++ b/app/libs/classes/mappers/tests/test_viva_workflow_completions_mapper.py
@@ -1,0 +1,111 @@
+from ..viva_workflow_completions_mapper import VivaWorkflowCompletionsMapper
+
+
+viva_workflow = {
+    'application': {
+        'completionsreceived': None,
+        'completions': {
+            'completion': [
+                'Hyreskontrakt',
+                'Underlag på alla sökta utgifter',
+                'Underlag på alla inkomster/tillgångar',
+                'Alla kontoutdrag för hela förra månaden och fram till idag',
+                'Kom in med...',
+            ]
+        },
+        'completiondescription': 'Du behöver komplettera ansökan.',
+    }
+}
+
+
+def test_initial_completions():
+    completion_mapper = VivaWorkflowCompletionsMapper(viva_workflow)
+    completion_list = completion_mapper.get_completion_list()
+    random_check = completion_mapper.is_random_check()
+
+    assert random_check is False
+    assert completion_list == [
+        {
+            'description': 'Hyreskontrakt',
+            'received': False,
+        },
+        {
+            'description': 'Underlag på alla sökta utgifter',
+            'received': False,
+        },
+        {
+            'description': 'Underlag på alla inkomster/tillgångar',
+            'received': False,
+        },
+        {
+            'description': 'Alla kontoutdrag för hela förra månaden och fram till idag',
+            'received': False,
+        },
+        {
+            'description': 'Kom in med...',
+            'received': False,
+        },
+    ]
+
+
+def test_is_random_check():
+    viva_workflow['application']['completiondescription'] = 'Du är utvald för stickprovskontroll.'
+
+    completion_mapper = VivaWorkflowCompletionsMapper(viva_workflow)
+    random_check = completion_mapper.is_random_check()
+
+    assert random_check is True
+
+
+def test_is_random_check_none():
+    viva_workflow['application']['completiondescription'] = None
+
+    completion_mapper = VivaWorkflowCompletionsMapper(viva_workflow)
+    random_check = completion_mapper.is_random_check()
+
+    assert random_check is False
+
+
+def test_completion_list_partially_approved():
+    viva_workflow['application']['completionsreceived'] = {
+        'completionreceived': [
+            'Hyreskontrakt',
+            'Underlag på alla sökta utgifter'
+        ]
+    }
+
+    completion_mapper = VivaWorkflowCompletionsMapper(viva_workflow)
+    completion_list = completion_mapper.get_completion_list()
+
+    assert completion_list == [
+        {
+            'description': 'Hyreskontrakt',
+            'received': True,
+        },
+        {
+            'description': 'Underlag på alla sökta utgifter',
+            'received': True,
+        },
+        {
+            'description': 'Underlag på alla inkomster/tillgångar',
+            'received': False,
+        },
+        {
+            'description': 'Alla kontoutdrag för hela förra månaden och fram till idag',
+            'received': False,
+        },
+        {
+            'description': 'Kom in med...',
+            'received': False,
+        },
+    ]
+
+
+def test_completion_list_all_received():
+    viva_workflow['application']['completionsreceived'] = None
+    viva_workflow['application']['completions'] = None
+
+    completion_mapper = VivaWorkflowCompletionsMapper(viva_workflow)
+    completion_list = completion_mapper.get_completion_list()
+
+    assert completion_list == []

--- a/app/libs/classes/mappers/viva_workflow_completions_mapper.py
+++ b/app/libs/classes/mappers/viva_workflow_completions_mapper.py
@@ -1,0 +1,29 @@
+class VivaWorkflowCompletionsMapper():
+
+    def __init__(self, viva_workflow):
+        self.viva_workflow = viva_workflow
+
+    def is_random_check(self):
+        description = self.viva_workflow['application']['completiondescription']
+        return (description and 'stickprov' in description) is True
+
+    def get_completion_list(self):
+        received = []
+        if self.viva_workflow['application']['completionsreceived']:
+            received = self.viva_workflow['application']['completionsreceived']['completionreceived']
+
+        if not self.viva_workflow['application']['completions']:
+            return []
+
+        requested = self.viva_workflow['application']['completions']['completion']
+
+        completion_list = list(self._set_completion(text=text, received=received)
+                               for text in requested)
+
+        return completion_list
+
+    def _set_completion(self, text, received):
+        return {
+            'description': text,
+            'received': text in received,
+        }

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,6 +1,7 @@
 from .my_pages import MyPages
 from .my_pages_workflows import MyPagesWorkflows
 from .my_pages_workflow_latest import MyPagesWorkflowLatest
+from .my_pages_workflow_completions import MyPagesWorkflowCompletions
 from .application_status import ApplicationStatus
 from .applications import Applications
 from .attachments import Attachments

--- a/app/routes/my_pages_workflow_completions.py
+++ b/app/routes/my_pages_workflow_completions.py
@@ -2,6 +2,7 @@ from flask_restful import Resource
 
 from ..libs import VivaMyPages
 
+from ..libs import VivaWorkflowCompletionsMapper
 from ..libs import hash_to_personal_number
 from ..libs import authenticate
 
@@ -11,18 +12,21 @@ class MyPagesWorkflowCompletions(Resource):
 
     def get(self, hash_id, workflow_id=None):
         personal_number = hash_to_personal_number(hash_id=hash_id)
-        self.my_pages = VivaMyPages(user=personal_number)
+        my_pages = VivaMyPages(user=personal_number)
 
-        self.workflow_id = workflow_id
+        workflow = my_pages.get_workflow(workflow_id=workflow_id)
 
-        return self._get_workflow_completions()
+        completion_mapper = VivaWorkflowCompletionsMapper(
+            viva_workflow=workflow)
 
-    def _get_workflow_completions(self):
+        completion_list = completion_mapper.get_completion_list()
 
         response = {
             'type': 'getWorkflowCompletions',
             'attributes': {
-                **self.my_pages.get_workflow_completions(workflow_id=self.workflow_id),
+                'requested': completion_list,
+                'isRandomCheck': completion_mapper.is_random_check(),
+                'completed': not completion_list,
             }
         }
 

--- a/app/routes/my_pages_workflow_completions.py
+++ b/app/routes/my_pages_workflow_completions.py
@@ -1,0 +1,29 @@
+from flask_restful import Resource
+
+from ..libs import VivaMyPages
+
+from ..libs import hash_to_personal_number
+from ..libs import authenticate
+
+
+class MyPagesWorkflowCompletions(Resource):
+    method_decorators = [authenticate]
+
+    def get(self, hash_id, workflow_id=None):
+        personal_number = hash_to_personal_number(hash_id=hash_id)
+        self.my_pages = VivaMyPages(user=personal_number)
+
+        self.workflow_id = workflow_id
+
+        return self._get_workflow_completions()
+
+    def _get_workflow_completions(self):
+
+        response = {
+            'type': 'getWorkflowCompletions',
+            'attributes': {
+                **self.my_pages.get_workflow_completions(workflow_id=self.workflow_id),
+            }
+        }
+
+        return response, 200

--- a/server.sh
+++ b/server.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
+ssh -M -S viva-ctrl-socket -fnNT -L 8080:a002527.hbgadm.hbgstad.se:80 hbgintra@intranat.helsingborg.se
+echo 'Tunnel established'
+
 echo 'VADA Development Server'
 pipenv run flask run
+
+ssh -S viva-ctrl-socket -O exit hbgintra@intranat.helsingborg.se
+echo 'Tunnel closed'


### PR DESCRIPTION
## Explain the changes you’ve made
Implemented new endpoint - `mypages/[hashid]/workflows/[workflowid]/completions` for retriving the list of completions required by the Viva administrator for the open application period

## How to test the changes?
1. Check out this branch
2. cd into project folder
3. run `./server.sh`
4. Execute an GET request on `http://localhost:5000/mypages/[hashid]/workflows/[workflow_id]/completions`

Optional
run tests with
`pytest' at the project root

Expected result

```json
{
  "type": "getWorkflowCompletions",
  "attributes": {
    "requested": [
      {
        "description": "Hyreskontrakt",
        "received": true
      },
      {
        "description": "Kvitto på betald hyra",
        "received": true
      },
      {
        "description": "Kvitto på betald elräkning",
        "received": true
      },
      {
        "description": "Inneboendekontrakt",
        "received": false
      },
      {
        "description": "Andrahandskontrakt",
        "received": false
      },
      {
        "description": "Underlag på alla sökta utgifter",
        "received": true
      },
      {
        "description": "Underlag på alla inkomster/tillgångar",
        "received": true
      },
      {
        "description": "Alla kontoutdrag för hela förra månaden och fram till idag",
        "received": true
      },
      {
        "description": "kom till saken",
        "received": true
      },
      {
        "description": "kom in med skiten",
        "received": true
      }
    ],
    "randomCheck": false,
    "completed": false
  }
}
```
