### PR TITLE
fix: 🐛 ignore empty answer value

### DIFF
--- a/app/libs/classes/application_answer/answer.py
+++ b/app/libs/classes/application_answer/answer.py
@@ -1,10 +1,10 @@
 class ApplicationAnswer:
-    def __init__(self, tags=None, value=None):
+    def __init__(self, tags: list, value):
         if not all(isinstance(tag, str) for tag in tags):
             raise TypeError(f'expected all items in {tags} to be strings')
 
-        if not isinstance(value, (str, int)):
-            raise TypeError(f'expected {value} to be string or integer')
+        if not isinstance(value, (str, int, float)):
+            raise TypeError(f'expected {value} to be string, integer or float')
 
         self.tags = tags
         self.value = value

--- a/app/libs/classes/application_answer/tests/test_zeep.py
+++ b/app/libs/classes/application_answer/tests/test_zeep.py
@@ -11,6 +11,65 @@ def answer(value, tags):
     return ApplicationAnswer(value=value, tags=tags)
 
 
+def test_get_posts_answer_amount_value_happy_path():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer(678.45, ['expenses', 'reskostnad', 'amount']),
+    ))
+
+    posts = zeep_dict._get_posts(post_group_name='EXPENSES')
+
+    assert posts == [
+        {
+            'TYPE': 'reskostnad',
+            'FREQUENCY': 12,
+            'DATE': '',
+            'PERIOD': '',
+            'APPLIESTO': 'applicant',
+            'DESCRIPTION': 'Reskostnad',
+            'AMOUNT': 678.45,
+        },
+    ]
+
+
+def test_get_posts_answer_amount_value_is_empty():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('', ['expenses', 'bredband', 'amount']),
+    ))
+
+    posts = zeep_dict._get_posts(post_group_name='EXPENSES')
+
+    assert posts == []
+
+
+def test_get_post_answer_amount_value_happy_path():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('5000', ['expenses', 'akuttandvard', 'amount']),
+    ))
+
+    posts = zeep_dict._get_post(
+        post_type='akuttandvard', post_type_attributes={})
+
+    assert posts == {
+        'TYPE': 'akuttandvard',
+        'FREQUENCY': 12,
+        'DATE': '',
+        'PERIOD': '',
+        'APPLIESTO': 'applicant',
+        'DESCRIPTION': 'Akut tandvård',
+    }
+
+
+def test_get_post_type_answers_happy_path():
+    answer_item = answer(6745, ['expenses', 'bostad', 'amount'])
+    zeep_dict = ZeepApplication(
+        application_answer_collection=answer_collection(answer_item))
+
+    posts = zeep_dict._get_post_type_answers(
+        post_name='bostad', post_group_name='EXPENSES')
+
+    assert posts == [answer_item]
+
+
 def test_answer_amount_value_is_float():
     zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
         answer(678.45, ['expenses', 'reskostnad', 'amount']),
@@ -52,4 +111,102 @@ def test_answer_amount_value_is_int():
                 }
             ],
         }
+    }
+
+
+def test_answer_amount_value_is_string():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('1234', ['expenses', 'boende', 'amount']),
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'boende',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': 'Hyra',
+                    'AMOUNT': 1234,
+                },
+            ],
+        },
+    }
+
+
+def test_answer_amount_value_is_empty():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('', ['expenses', 'annat', 'amount']),
+    ))
+
+    assert zeep_dict == {}
+
+
+def test_answer_description_value_happy_path():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('Stångkorv', ['expenses', 'annat', 'description']),
+        answer(900.12, ['expenses', 'annat', 'amount']),
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'annat',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': 'Stångkorv 900.12',
+                    'AMOUNT': 900.12,
+                },
+            ],
+        },
+    }
+
+
+def test_answer_description_value_is_empty():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('', ['expenses', 'annat', 'description']),
+        answer(900, ['expenses', 'annat', 'amount']),
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'annat',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': '900.0',
+                    'AMOUNT': 900.0,
+                },
+            ],
+        },
+    }
+
+
+def test_answer_description_value_default_happy_path():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer(700, ['expenses', 'annat', 'amount']),
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'annat',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': 'Övrig utgift',
+                    'AMOUNT': 700.0,
+                },
+            ],
+        },
     }

--- a/app/libs/classes/application_answer/tests/test_zeep.py
+++ b/app/libs/classes/application_answer/tests/test_zeep.py
@@ -53,11 +53,3 @@ def test_answer_amount_value_is_int():
             ],
         }
     }
-
-
-def test_answer_amount_value_is_empty():
-    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
-        answer('', ['expenses', 'boende', 'amount'])
-    ))
-
-    assert bool(zeep_dict) is False

--- a/app/libs/classes/application_answer/tests/test_zeep.py
+++ b/app/libs/classes/application_answer/tests/test_zeep.py
@@ -1,0 +1,63 @@
+from .. import ApplicationAnswer
+from .. import ApplicationAnswerCollection
+from .. import ZeepApplication
+
+
+def answer_collection(*args):
+    return ApplicationAnswerCollection(*args)
+
+
+def answer(value, tags):
+    return ApplicationAnswer(value=value, tags=tags)
+
+
+def test_answer_amount_value_is_float():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer(678.45, ['expenses', 'reskostnad', 'amount']),
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'reskostnad',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': 'Reskostnad',
+                    'AMOUNT': 678.45,
+                }
+            ],
+        }
+    }
+
+
+def test_answer_amount_value_is_int():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer(1234, ['expenses', 'boende', 'amount'])
+    ))
+
+    assert zeep_dict == {
+        'EXPENSES': {
+            'EXPENSE': [
+                {
+                    'TYPE': 'boende',
+                    'FREQUENCY': 12,
+                    'DATE': '',
+                    'PERIOD': '',
+                    'APPLIESTO': 'applicant',
+                    'DESCRIPTION': 'Hyra',
+                    'AMOUNT': 1234,
+                }
+            ],
+        }
+    }
+
+
+def test_answer_amount_value_is_empty():
+    zeep_dict = ZeepApplication(application_answer_collection=answer_collection(
+        answer('', ['expenses', 'boende', 'amount'])
+    ))
+
+    assert bool(zeep_dict) is False

--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -67,7 +67,7 @@ class ZeepApplication(dict):
                 posts_key = trim_last_character(post_group_name)
                 self[post_group_name] = {posts_key: posts}
 
-    def _get_posts(self, post_group_name: str = None):
+    def _get_posts(self, post_group_name: str = ''):
         posts = []
 
         for post_type in ZeepApplication.POST_TYPES.keys():
@@ -119,7 +119,8 @@ class ZeepApplication(dict):
                     milliseconds=value)
 
             elif attribute == 'AMOUNT':
-                post[attribute] = float(value)
+                if isinstance(value, (int, float)):
+                    post[attribute] = float(value)
 
             elif attribute == 'APPLIESTO' and value == 'COAPPLICANT':
                 post[attribute] = 'coapplicant'
@@ -143,8 +144,10 @@ class ZeepApplication(dict):
             for post_type_attribute in ZeepApplication.POST_TYPE_ATTRIBUTES:
                 if post_answer.has_tag(post_type_attribute.lower()):
 
-                    post_value = post_answer.value
-                    post_type_collection[post_type_key][post_type_attribute] = post_value
+                    print(post_type_key)
+                    print(post_answer.value)
+                    if post_answer.value:
+                        post_type_collection[post_type_key][post_type_attribute] = post_answer.value
 
         return post_type_collection
 
@@ -152,7 +155,7 @@ class ZeepApplication(dict):
         post_tags = [post_name.lower(), post_group_name.lower()]
         return self.application_answer_collection.filter_by_tags(tags=post_tags)
 
-    def _get_post_description(self, description, amount):
+    def _get_post_description(self, description: str, amount: int):
         if isinstance(amount, int):
             return f'{description} {amount}'
         return description

--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -142,12 +142,8 @@ class ZeepApplication(dict):
                 post_type_collection[post_type_key] = dict()
 
             for post_type_attribute in ZeepApplication.POST_TYPE_ATTRIBUTES:
-                if post_answer.has_tag(post_type_attribute.lower()):
-
-                    print(post_type_key)
-                    print(post_answer.value)
-                    if post_answer.value:
-                        post_type_collection[post_type_key][post_type_attribute] = post_answer.value
+                if post_answer.has_tag(post_type_attribute.lower()) and post_answer.value:
+                    post_type_collection[post_type_key][post_type_attribute] = post_answer.value
 
         return post_type_collection
 

--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -142,7 +142,7 @@ class ZeepApplication(dict):
                 post_type_collection[post_type_key] = dict()
 
             for post_type_attribute in ZeepApplication.POST_TYPE_ATTRIBUTES:
-                if post_answer.has_tag(post_type_attribute.lower()) and post_answer.value:
+                if post_answer.has_tag(post_type_attribute.lower()):
                     post_type_collection[post_type_key][post_type_attribute] = post_answer.value
 
         return post_type_collection

--- a/app/libs/classes/application_answer/zeep.py
+++ b/app/libs/classes/application_answer/zeep.py
@@ -5,15 +5,6 @@ from ...datetime_helper import milliseconds_to_date_string
 
 
 class ZeepApplication(dict):
-    EMPTY_POST = {
-        'TYPE': None,
-        'FREQUENCY': 12,
-        'DATE': None,
-        'PERIOD': None,
-        'APPLIESTO': 'applicant',
-        'DESCRIPTION': None
-    }
-
     POST_GROUPS = (
         'EXPENSES',
         'INCOMES',
@@ -81,8 +72,7 @@ class ZeepApplication(dict):
                 post_type=post_type, post_answers=post_type_answers)
 
             for post_type_attributes in post_type_collection.values():
-
-                if ('AMOUNT') not in post_type_attributes:
+                if post_type_attributes['AMOUNT'] == '':
                     continue
 
                 post = self._get_post(post_type, post_type_attributes)
@@ -119,7 +109,7 @@ class ZeepApplication(dict):
                     milliseconds=value)
 
             elif attribute == 'AMOUNT':
-                if isinstance(value, (int, float)):
+                if isinstance(value, (int, float, str)):
                     post[attribute] = float(value)
 
             elif attribute == 'APPLIESTO' and value == 'COAPPLICANT':
@@ -151,7 +141,9 @@ class ZeepApplication(dict):
         post_tags = [post_name.lower(), post_group_name.lower()]
         return self.application_answer_collection.filter_by_tags(tags=post_tags)
 
-    def _get_post_description(self, description: str, amount: int):
-        if isinstance(amount, int):
-            return f'{description} {amount}'
+    def _get_post_description(self, description: str, amount):
+        if isinstance(amount, (int, float, str)):
+            if description:
+                return f'{description} {float(amount)}'
+            return f'{float(amount)}'
         return description


### PR DESCRIPTION
Form answers can contain empty values. This PR' fixes this by checking if value is of type int or float before putting it in the 'AMOUNT' param.